### PR TITLE
Allow self

### DIFF
--- a/style/ruby/README.md
+++ b/style/ruby/README.md
@@ -11,8 +11,6 @@ Ruby
 * Avoid explicit return statements.
 * Avoid using semicolons.
 * Avoid bang (!) method names. Prefer descriptive names.
-* Don't use `self` explicitly anywhere except class methods (`def self.method`)
-  and assignments (`self.attribute =`).
 * Prefer nested class and module definitions over the shorthand version
   [Example][class definition example]
 * Prefer `detect` over `find`.


### PR DESCRIPTION
Try not to write `self.xxx = y` in a ActiveRecord class and enjoy the result: You ll create an local variable instead of updating your instance field.
This rule is simply not feasible
